### PR TITLE
[feature] 서버 환경 세팅 및 전자서명 암호화 코드 구현

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -1,0 +1,55 @@
+from flask import Flask, request, jsonify
+from cryptography.hazmat.primitives.asymmetric import rsa, padding
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
+
+app = Flask(__name__)
+
+# RSA 키 생성
+private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+public_key = private_key.public_key()
+
+# 공개키를 PEM 형식으로 저장
+public_pem = public_key.public_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PublicFormat.SubjectPublicKeyInfo
+)
+
+@app.route('/get_public_key', methods=['GET'])
+def get_public_key():
+    """클라이언트가 사용할 공개키 제공"""
+    return public_pem.decode('utf-8')
+
+@app.route('/submit_vote', methods=['POST'])
+def submit_vote():
+    """클라이언트에서 암호화된 투표 데이터를 수신"""
+    data = request.get_json()
+    encrypted_vote = bytes.fromhex(data['encrypted_vote'])
+
+    # 투표 데이터 복호화
+    try:
+        vote_data = private_key.decrypt(
+            encrypted_vote,
+            padding.OAEP(
+                mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                algorithm=hashes.SHA256(),
+                label=None
+            )
+        )
+        print(f"Received vote: {vote_data.decode()}")
+        
+        # 투표 데이터에 서명
+        signature = private_key.sign(
+            vote_data,
+            padding.PSS(
+                mgf=padding.MGF1(hashes.SHA256()),
+                salt_length=padding.PSS.MAX_LENGTH
+            ),
+            Prehashed(hashes.SHA256())
+        )
+        return jsonify({'signature': signature.hex()})
+    except Exception as e:
+        return jsonify({'error': str(e)}), 400
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## 🌱 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가 ✨ 
- [ ] 기능 삭제 🔥
- [ ] 버그 수정 🐛
- [ ] 코드 형태 개선 🎨
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 🔨

## 🔗 연관된 이슈
### #1

## 📝 변경 사항
RSA 기반 공개키 암호화와 디지털 서명을 활용한 전자투표 시스템 서버 모듈을 구현합니다. 클라이언트와의 데이터 전송 보안 및 무결성을 보장하기 위해 cryptography 라이브러리를 사용하여 주요 기능을 완성하였습니다.

### 📌 추가된 주요 기능
**1. RSA 키 생성 및 공개키 제공 API**
- 서버 실행 시 RSA 키 쌍을 생성합니다.
- `/get_public_key` 엔드포인트를 통해 PEM 형식의 공개키를 클라이언트에 제공합니다.

**2. 투표 데이터 암호화 및 복호화**
- 클라이언트에서 암호화된 투표 데이터를 `/submit_vote` 엔드포인트를 통해 서버로 전달합니다.
- 서버는 RSA 개인키를 사용하여 투표 데이터를 복호화하고 로그에 기록합니다.

**3. 투표 데이터 서명 및 반환**
- 복호화한 투표 데이터에 RSA 개인키로 서명합니다.
- 서명된 데이터를 클라이언트에 반환하여 무결성과 인증성 보장합니다.

### 📌 핵심 코드 설명
**1. RSA 키 생성 및 공개키 반환**
```python
private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
public_key = private_key.public_key()

public_pem = public_key.public_bytes(
    encoding=serialization.Encoding.PEM,
    format=serialization.PublicFormat.SubjectPublicKeyInfo
)

@app.route('/get_public_key', methods=['GET'])
def get_public_key():
    return public_pem.decode('utf-8')

```
RSA 키를 메모리에 생성하여 서버 전체에서 사용할 수 있도록 유지하고, 공개 키를 클라이언트에서 사용할 수 있도록 PEM 형식을 사용합니다.

**2. 투표 데이터 복호화 및 서명**
```python
encrypted_vote = bytes.fromhex(data['encrypted_vote'])
vote_data = private_key.decrypt(
    encrypted_vote,
    padding.OAEP(
        mgf=padding.MGF1(algorithm=hashes.SHA256()),
        algorithm=hashes.SHA256(),
        label=None
    )
)
signature = private_key.sign(
    vote_data,
    padding.PSS(
        mgf=padding.MGF1(hashes.SHA256()),
        salt_length=padding.PSS.MAX_LENGTH
    ),
    Prehashed(hashes.SHA256())
)

```
클라이언트에서 받은 데이터를 복호화하여 투표 내용을 확인하고, 복호화된 데이터에 개인키로 서명하여 무결성 및 부인 방지성을 진행합니다.


## ✒️ 이슈 사항
- `/submit_vote` 엔드포인트에서 예외 처리 로직이 충분한지 확인합니다.
